### PR TITLE
Added git-log pretty-format string

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -8,3 +8,12 @@
 	prompt = false
 [pull]
 	rebase = false
+
+# git log
+# --pretty=format:"%h%x09%cn%x09%ce%x09%cd%x09%an%x09%ae%x09%ad%x09%s"
+# --date=format:"%Y/%m/%d%t%T"
+#
+# git log pretty format table headers
+# Commit id	Committer name	Committer email	Commit date	Commit time
+# Author name	Author email	Author date	Author time	Commit message
+#


### PR DESCRIPTION
This is used to generate git log in table format.
Import it into it spreadsheet for further analysis and manipulation.