### PR TITLE
Refactor/remove hardcoded wrapper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ stow --dotfiles vimrc -t ~/
 # .vimrc  -> ../../home/.../dotfiles/vimrc/dot-vimrc
 ```
 
+When gnu stow is not available use `ln` command
+
+```bash
+ln -s `realpath --relative-to=$HOME ~/scripts/git-prompt` ~/.bashrc_part_git_prompt_sym_link.sh
+ln -s `realpath --relative-to=$HOME ~/scripts/system_specific_settings.sh` ~/.bashrc_part_system_specific_config_sym_link.sh
+```
+
 ### Uninstall
 
 ```bash

--- a/bashrc/dot-bashrc_parts/bash_prompt_wrapper.sh
+++ b/bashrc/dot-bashrc_parts/bash_prompt_wrapper.sh
@@ -1,10 +1,20 @@
-#!/bin/bash
 # Prompt customization wrapper
 
 # Bash colors
 if [ -f ~/.bashrc_parts/common/bash_colors.sh ]; then
     source ~/.bashrc_parts/common/bash_colors.sh
 fi
+
+# Control git prompt via sym link instead of global variable for flexibilty.
+# TIPS: As we can't remember or see the variable names, it is better to control
+# some functions via sym links.
+function is_git_prompt_sym_link_exists() {
+    local enable_git_ps1=''
+    if [ -f ~/.bashrc_part_git_prompt_sym_link.sh ]; then
+        enable_git_ps1='yes'
+    fi
+    echo "$enable_git_ps1"
+}
 
 # __head_ps1 = debian_chroot + user + host + cwd
 function make_color_head_ps1() {
@@ -55,7 +65,12 @@ function make_color_tail_ps1() {
 # __ps1_line = __head_ps1 + __body_ps1_git + __tail_ps1
 function make_color_prompt_line() {
     local __ps1_line="$(make_color_head_ps1)"
-    __ps1_line+="$(make_color_body_ps1_git)"
+
+    local __is_git_ps1="$(is_git_prompt_sym_link_exists)"
+    if [ "$__is_git_ps1" = 'yes' ]; then
+        __ps1_line+="$(make_color_body_ps1_git)"
+    fi
+
     __ps1_line+="$(make_color_tail_ps1)"
     PS1="$__ps1_line"
 }
@@ -65,7 +80,14 @@ function make_colorless_prompt_line() {
     local __head_ps1="${debian_chroot:+($debian_chroot)}\u@\h:"
     local __body_ps1='\W'
     local __tail_ps1='$ '
-    local __ps1_line="$__head_ps1$__body_ps1$(__git_ps1 " (%s)")$__tail_ps1"
+    local __ps1_line="$__head_ps1$__body_ps1"
+
+    local __is_git_ps1="$(is_git_prompt_sym_link_exists)"
+    if [ "$__is_git_ps1" = 'yes' ]; then
+        __ps1_line+="$(__git_ps1 " (%s)")"
+    fi
+
+    __ps1_line+="$__tail_ps1"
     PS1=$__ps1_line
 }
 
@@ -118,7 +140,10 @@ trap 'tput sgr0' DEBUG
 export PROMPT_COMMAND=prompt_command
 
 # Bash prompt cusomtization for git
-if [ -f ~/.bashrc_parts/common/git_prompt_wrapper.sh ]; then
+# NOTE: source the git prompt script only once to optimize prompt command
+# performance. But it forces the user to re-login or re-source ~/.bashrc
+# for the new changes to take effect.
+if [ -f ~/.bashrc_part_git_prompt_sym_link.sh ]; then
     # git ps1 options
     GIT_PS1_SHOWDIRTYSTATE='y'
     GIT_PS1_SHOWCOLORHINTS='y'
@@ -127,6 +152,6 @@ if [ -f ~/.bashrc_parts/common/git_prompt_wrapper.sh ]; then
     GIT_PS1_DESCRIBE_STYLE='contains'
     GIT_PS1_SHOWUPSTREAM='auto'
 
-    # source git prompt wrapper script
-    source ~/.bashrc_parts/common/git_prompt_wrapper.sh
+    # source sym link to git prompt script
+    source ~/.bashrc_part_git_prompt_sym_link.sh
 fi

--- a/bashrc/dot-bashrc_parts/bash_system_config_wrapper.sh
+++ b/bashrc/dot-bashrc_parts/bash_system_config_wrapper.sh
@@ -1,4 +1,4 @@
 # sym link to system specific bashrc here
-if [ -f ~/.bash_system_config_sym_link.sh ]; then
-    source ~/.bash_system_config_sym_link.sh
+if [ -f ~/.bashrc_part_system_specific_config_sym_link.sh ]; then
+    source ~/.bashrc_part_system_specific_config_sym_link.sh
 fi

--- a/bashrc/dot-bashrc_parts/common/git_prompt_wrapper.sh
+++ b/bashrc/dot-bashrc_parts/common/git_prompt_wrapper.sh
@@ -1,4 +1,0 @@
-# sym link to git prompt script
-if [ -f ~/.bashrc_part_git_prompt_sym_link ]; then
-    source ~/.bashrc_part_git_prompt_sym_link
-fi

--- a/bashrc/dot-bashrc_parts/common/git_prompt_wrapper.sh
+++ b/bashrc/dot-bashrc_parts/common/git_prompt_wrapper.sh
@@ -1,4 +1,4 @@
-# sym link to git prompt script from git core team
-if [[ -e /etc/bash_completion.d/git-prompt ]]; then
-    . /etc/bash_completion.d/git-prompt
+# sym link to git prompt script
+if [ -f ~/.bashrc_part_git_prompt_sym_link ]; then
+    source ~/.bashrc_part_git_prompt_sym_link
 fi


### PR DESCRIPTION
* Remove hardcoded path to git-prompt script
* Add readable sym link names in wrapper scripts.
* Update README.md for installing without stow.
* Control git ps1 by a sym link in $HOME